### PR TITLE
Fix typo in VisualEvent.js

### DIFF
--- a/js/VisualEvent.js
+++ b/js/VisualEvent.js
@@ -860,7 +860,7 @@ VisualEvent.prototype = {
 
 	/**
 	 * Create an event oject based on the type to trigger an event - cross-platform
-	 *  @param {event} originalEvt The original event (click) which cased this function to run
+	 *  @param {event} originalEvt The original event (click) which caused this function to run
 	 *  @param {string} type Type of event
 	 *  @param {node} target Target node of the event
 	 *  @returns {event} The constructed event


### PR DESCRIPTION
This is a minor typo fix in a comment on line 863 of `js/VisualEvent.js`
