### PR TITLE
Added funcObject support for jQuery parser

### DIFF
--- a/js/parsers/jQuery.js
+++ b/js/parsers/jQuery.js
@@ -83,7 +83,7 @@ function jQueryGeneric (elements, eventsObject, node) {
 			events = $._data(eventsObject, 'events');
 		}
 
-		var func;
+		var func, funcObject;
 
 		for ( var type in events ) {
 			if ( events.hasOwnProperty( type ) ) {
@@ -114,13 +114,16 @@ function jQueryGeneric (elements, eventsObject, node) {
 							} );
 
 							if ( typeof oEvents[j].origHandler != 'undefined' ) {
-								func = oEvents[j].origHandler.toString();
+								funcObject = oEvents[j].origHandler;
+								func = funcObject.toString();
 							}
 							else if ( typeof oEvents[j].handler != 'undefined' ) {
-								func = oEvents[j].handler.toString();
+								funcObject = oEvents[j].handler;
+								func = funcObject.toString();
 							}
 							else {
-								func = oEvents[j].toString();
+								funcObject = oEvents[j];
+								func = funcObject.toString();
 							}
 
 							/* We use jQuery for the Visual Event events... don't really want to display them */
@@ -129,6 +132,7 @@ function jQueryGeneric (elements, eventsObject, node) {
 								elements[ elements.length-1 ].listeners.push( {
 									"type": type,
 									"func": func,
+									"funcObject": funcObject,
 									"removed": false,
 									"source": sjQuery
 								} );


### PR DESCRIPTION
This is a tentative pull request to add support in VisualEvent for getting the original function objects in addition to the current function source.

_Why this?_ Because I'm investigating the event listeners attached to invisible elements, which are not visible in the VisualEvent UI. Since you can't interact with them using the UI, you can't get event handler function definition AFAIK

 I got the idea to have the original function object, attached to the listener object the parser return. This is very convenient because in modern browsers you can inspect function object properties like it's prototype, name, number of arguments, etc.

The way of accessing the hidden elements using the VisualEvent instance and filter them. For example, if `jQuery` is available you can do the following to get them.

`var invisible = VisualEvent.instance.s.elements.filter(function(el){ return jQuery(el.node).is(':not(:visible)') })`

I made this change only for the jQuery.js parser, only to showcase it. If you like the idea I can go further and apply this change for the other parsers.
